### PR TITLE
Update estrella version to fix #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "chalk": "^4.1.0",
         "cloudflare-worker-mock": "^1.2.0",
         "esbuild": "^0.8.18",
-        "estrella": "^1.2.10",
+        "estrella": "^1.3.10",
         "fs-extra": "^9.0.1",
         "jest": "^27.3.1",
         "jest-environment-miniflare": "^2.0.0-rc.2",


### PR DESCRIPTION
Fixes #3 by using a version of estrella which builds on Apple silicon but does not break the current build.js script.