### PR TITLE
make @cloudflare/workers-types visible by Typescript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,9 @@
         "lib": [
             "esnext"
         ],
-        "types": [
-            "@cloudflare/workers-types"
+        "typeRoots": [
+            "./node_modules/@types",
+            "./node_modules/@cloudflare/workers-types"
         ],
         "moduleResolution": "node",
         "strict": true,


### PR DESCRIPTION
**Issue:** the original tsconfig file, would include _@cloudflare/workers-types_ types like so:

- ./node_modules/@types/@cloudflare/workers-types,
- ../node_modules/@types/@cloudflare/workers-types,
- ../../node_modules/@types/@cloudflare/workers-types and so on, as per [the reference page](https://www.typescriptlang.org/tsconfig#types).

**Solution:** Since the actual path to Cloudflare Workers types is _./node_modules/@cloudflare/workers-types_, I made this PR according to [the tsconfig reference page](https://www.typescriptlang.org/tsconfig#typeRoots).

Strangely, I cannot get a screenshot of the corresponding VS Code error anymore now that I made this change on my machine.